### PR TITLE
adds strip path format with vowel removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ prmt '{path} {rust} {git}'
 prmt '{path::a}'                  # /home/user/projects (absolute path)
 prmt '{path::r}'                  # ~/projects (relative with ~)
 prmt '{path::s}'                  # projects (short - last dir only)
+prmt '{path::strip}'              # ~/prjct (vowels stripped after first char)
 prmt '{rust:red:s}'               # 1.89 in red (short version)
 prmt '{rust:red:m:v:}'            # v1 in red (major version with prefix)
 prmt '{path:cyan:s:[:]}'          # [projects] in cyan

--- a/src/modules/path.rs
+++ b/src/modules/path.rs
@@ -45,6 +45,34 @@ fn normalize_relative_path(current_dir: &Path) -> String {
     normalize_separators(current_dir.to_string_lossy().to_string())
 }
 
+fn strip_vowels(path: &str) -> String {
+    let mut result = String::with_capacity(path.len());
+    let mut segment_start = true;
+
+    for ch in path.chars() {
+        if ch == '/' {
+            segment_start = true;
+            result.push(ch);
+            continue;
+        }
+
+        if segment_start {
+            segment_start = false;
+            result.push(ch);
+            continue;
+        }
+
+        let lower = ch.to_ascii_lowercase();
+        if matches!(lower, 'a' | 'e' | 'i' | 'o' | 'u') {
+            continue;
+        }
+
+        result.push(ch);
+    }
+
+    result
+}
+
 impl Module for PathModule {
     fn render(&self, format: &str, _context: &ModuleContext) -> Result<Option<String>> {
         let current_dir = match env::current_dir() {
@@ -55,6 +83,7 @@ impl Module for PathModule {
         match format {
             "" | "relative" | "r" => Ok(Some(normalize_relative_path(&current_dir))),
             "absolute" | "a" | "f" => Ok(Some(current_dir.to_string_lossy().to_string())),
+            "strip" | "stripped" => Ok(Some(strip_vowels(&normalize_relative_path(&current_dir)))),
             "short" | "s" => Ok(current_dir
                 .file_name()
                 .and_then(|n| n.to_str())
@@ -97,7 +126,8 @@ impl Module for PathModule {
             _ => Err(PromptError::InvalidFormat {
                 module: "path".to_string(),
                 format: format.to_string(),
-                valid_formats: "relative, r, absolute, a, f, short, s, truncate:N".to_string(),
+                valid_formats: "relative, r, absolute, a, f, short, s, strip, stripped, truncate:N"
+                    .to_string(),
             }),
         }
     }
@@ -245,5 +275,12 @@ mod tests {
         assert_eq!(value, normalize_expected(&similar));
 
         let _ = fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn strip_vowels_helper_removes_vowels_after_first_char() {
+        assert_eq!(strip_vowels("~/project"), "~/prjct");
+        assert_eq!(strip_vowels("/alpha/beta"), "/alph/bt");
+        assert_eq!(strip_vowels("simple"), "smpl");
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -117,6 +117,9 @@ fn test_path_formats() {
     let result_absolute_a = execute("{path::a}", true, None, false).expect("Failed to execute");
     let result_short = execute("{path::short}", true, None, false).expect("Failed to execute");
     let result_short_s = execute("{path::s}", true, None, false).expect("Failed to execute");
+    let result_strip = execute("{path::strip}", true, None, false).expect("Failed to execute");
+    let result_stripped =
+        execute("{path::stripped}", true, None, false).expect("Failed to execute");
     let result_default = execute("{path}", true, None, false).expect("Failed to execute");
 
     // Short should be basename only
@@ -130,6 +133,10 @@ fn test_path_formats() {
     assert!(result_relative.contains(basename) || result_relative.contains("~"));
     assert_eq!(result_relative, result_relative_r); // Short and long forms should match
     assert_eq!(result_relative, result_default); // Default should be relative
+
+    // Strip formats should be at most as long as relative output
+    assert!(result_strip.len() <= result_relative.len());
+    assert_eq!(result_strip, result_stripped);
 
     // Absolute formats should never contain ~ and should always contain the basename
     assert!(!result_absolute.contains("~"));


### PR DESCRIPTION
- introduce {path::strip}/{path::stripped} output option in the path module
- extend integration test coverage for the new aliases
- document the strip format in the README usage examples