### PR TITLE
fix: Auto-detect shell wrapping and fix Zsh docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,15 @@ PS1='$(prmt --code $? "{path:cyan} {git:purple} {ok:green}{fail:red} ")'
 PS1='$(prmt --code $? "{path:#89dceb} {git:#f9e2af} {ok:#a6e3a1}{fail:#f38ba8} ")'
 ```
 
-**Zsh** – Add to `~/.zshrc`:
+**Zsh** – Add to `~/.zshrc` (auto-detected by default; `--shell zsh` forces wrapping):
 ```bash
 setopt PROMPT_SUBST
 
 # Simple with named colors
-PROMPT='$(prmt --code $? "{path:cyan} {git:purple} {ok:green}{fail:red} ")'
+PROMPT='$(prmt --shell zsh --code $? "{path:cyan} {git:purple} {ok:green}{fail:red} ")'
 
 # Or with hex colors for precise theming
-PROMPT='$(prmt --code $? "{path:#89dceb} {git:#f9e2af} {ok:#a6e3a1}{fail:#f38ba8} ")'
+PROMPT='$(prmt --shell zsh --code $? "{path:#89dceb} {git:#f9e2af} {ok:#a6e3a1}{fail:#f38ba8} ")'
 ```
 
 **Fish** – Add to `~/.config/fish/config.fish`:


### PR DESCRIPTION
- Detect shell from $ZSH_VERSION/$SHELL when stdout is a TTY and --shell isn’t provided; fall back to explicit --shell when given.
- Keep Shell::None for non-TTY output to avoid surprising pipelines.
- Update Zsh README examples to pass --shell zsh and mention autodetect to prevent ghosting.
Fixed #45 
